### PR TITLE
Improve SIRH backoffice layout

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,10 +1,4 @@
-<header class="bg-blue-700 text-white p-4">
-    <h1 class="text-2xl font-bold">SIRH - {{ page.title }}</h1>
-    <nav class="mt-2 space-x-4">
-        <a href="{{ '/' | relative_url }}" class="underline">Accueil</a>
-        <a href="{{ '/admin.html' | relative_url }}" class="underline">Tableau de bord</a>
-        <a href="{{ '/employes.html' | relative_url }}" class="underline">Employés</a>
-        <a href="{{ '/departements.html' | relative_url }}" class="underline">Départements</a>
-        <a href="{{ '/conges.html' | relative_url }}" class="underline">Congés</a>
-    </nav>
+<header class="bg-blue-700 text-white p-4 flex justify-between items-center">
+    <h1 class="text-2xl font-bold">SIRH</h1>
+    <div class="text-sm">Connecté : <span class="font-semibold">admin@example.com</span></div>
 </header>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,0 +1,9 @@
+<aside class="w-64 bg-blue-100 p-4">
+    <nav class="space-y-2">
+        <a href="{{ '/' | relative_url }}" class="block py-2 px-3 rounded hover:bg-blue-200">Accueil</a>
+        <a href="{{ '/admin.html' | relative_url }}" class="block py-2 px-3 rounded hover:bg-blue-200">Tableau de bord</a>
+        <a href="{{ '/employes.html' | relative_url }}" class="block py-2 px-3 rounded hover:bg-blue-200">Employés</a>
+        <a href="{{ '/departements.html' | relative_url }}" class="block py-2 px-3 rounded hover:bg-blue-200">Départements</a>
+        <a href="{{ '/conges.html' | relative_url }}" class="block py-2 px-3 rounded hover:bg-blue-200">Congés</a>
+    </nav>
+</aside>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,10 +6,13 @@
     <title>{{ page.title }}</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-blue-50 min-h-screen">
+<body class="bg-blue-50 min-h-screen flex flex-col">
     {% include header.html %}
-    <main class="p-6">
-        {{ content }}
-    </main>
+    <div class="flex flex-1">
+        {% include sidebar.html %}
+        <main class="flex-1 p-6">
+            {{ content }}
+        </main>
+    </div>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -3,6 +3,7 @@ layout: default
 title: Tableau de bord
 ---
 
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
 <div class="bg-white shadow rounded p-4">
     <h2 class="text-xl font-semibold text-blue-700 mb-4">Liste des employés</h2>
     <table class="min-w-full text-left text-sm">

--- a/conges.html
+++ b/conges.html
@@ -3,6 +3,7 @@ layout: default
 title: Congés
 ---
 
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
 <div class="bg-white shadow rounded p-4">
     <h2 class="text-xl font-semibold text-blue-700 mb-4">Historique des demandes de congés</h2>
     <table class="min-w-full text-left text-sm">

--- a/departements.html
+++ b/departements.html
@@ -3,6 +3,7 @@ layout: default
 title: Départements
 ---
 
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
 <div class="bg-white shadow rounded p-4">
     <h2 class="text-xl font-semibold text-blue-700 mb-4">Liste des départements</h2>
     <ul class="list-disc pl-6 space-y-1">

--- a/employes.html
+++ b/employes.html
@@ -3,6 +3,7 @@ layout: default
 title: Employés
 ---
 
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
 <div class="bg-white shadow rounded p-4">
     <h2 class="text-xl font-semibold text-blue-700 mb-4">Liste détaillée des employés</h2>
     <table class="min-w-full text-left text-sm">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@ layout: default
 title: Accueil
 ---
 
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
 <p class="mb-4">Choisissez une section de l'administration :</p>
 <nav class="space-y-2">
     <a href="admin.html" class="block bg-white p-4 rounded shadow hover:bg-blue-50">Tableau de bord</a>


### PR DESCRIPTION
## Summary
- add a sidebar navigation include
- simplify header and show logged user
- update default layout to use sidebar
- display page title on every page

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407d94fd408330bba639c76c49167b