### PR TITLE
Add Dominique IA documentation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,10 @@
-<header class="bg-gradient-to-r from-blue-700 to-purple-600 text-white p-4 flex justify-between items-center">
-    <h1 class="text-2xl font-bold flex items-center"><i class="fa-solid fa-building mr-2"></i> SIRH NextGen</h1>
+<header class="bg-gradient-to-r from-sky-800 to-sky-600 text-white p-4 flex justify-between items-center">
+    <div class="flex items-center gap-2">
+        <button id="menu-toggle" class="md:hidden text-2xl">
+            <i class="fa-solid fa-bars"></i>
+        </button>
+        <h1 class="text-2xl font-bold flex items-center"><i class="fa-solid fa-building mr-2"></i> Dominique IA</h1>
+    </div>
     <div class="text-sm flex items-center gap-2">
         <i class="fa-solid fa-user-circle"></i>
         <span>Connecté : <span class="font-semibold">admin@example.com</span></span>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,9 +1,13 @@
-<aside class="w-64 bg-blue-100 p-4">
+<aside id="sidebar" class="fixed md:static inset-y-0 left-0 w-64 bg-sky-100 p-4 transform -translate-x-full md:translate-x-0 transition-transform md:block z-20">
     <nav class="space-y-2 text-gray-700">
-        <a href="{{ '/' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-blue-200"><i class="fa-solid fa-house"></i> Accueil</a>
-        <a href="{{ '/admin.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-blue-200"><i class="fa-solid fa-chart-line"></i> Tableau de bord</a>
-        <a href="{{ '/employes.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-blue-200"><i class="fa-solid fa-users"></i> Employés</a>
-        <a href="{{ '/departements.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-blue-200"><i class="fa-solid fa-building"></i> Départements</a>
-        <a href="{{ '/conges.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-blue-200"><i class="fa-solid fa-calendar-days"></i> Congés</a>
+        <a href="{{ '/' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-house"></i> Accueil</a>
+        <a href="{{ '/architecture.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-diagram-project"></i> Architecture</a>
+        <a href="{{ '/frontend.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-desktop"></i> Interface</a>
+        <a href="{{ '/securite.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-shield-halved"></i> Sécurité</a>
+        <a href="{{ '/ci-cd.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-rocket"></i> Déploiement</a>
+        <a href="{{ '/regles.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-list-check"></i> Règles</a>
+        <a href="{{ '/observabilite.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-chart-bar"></i> Observabilité</a>
+        <a href="{{ '/cout.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-euro-sign"></i> Coût</a>
+        <a href="{{ '/roadmap.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-road"></i> Roadmap</a>
     </nav>
 </aside>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,13 +7,22 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body class="bg-blue-50 min-h-screen flex flex-col">
+<body class="bg-sky-50 min-h-screen flex flex-col">
     {% include header.html %}
     <div class="flex flex-1">
         {% include sidebar.html %}
-        <main class="flex-1 p-6">
+        <main id="content" class="flex-1 p-6 md:ml-64 transition-all">
             {{ content }}
         </main>
     </div>
+    <script>
+        const btn = document.getElementById('menu-toggle');
+        if (btn) {
+            btn.addEventListener('click', () => {
+                const sidebar = document.getElementById('sidebar');
+                sidebar.classList.toggle('-translate-x-full');
+            });
+        }
+    </script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -6,7 +6,7 @@ title: Tableau de bord
 <h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
 <p class="mb-4">Cet espace vous donne un aperçu rapide des employés actifs.</p>
 <div class="bg-white shadow rounded p-4">
-    <h2 class="text-xl font-semibold text-blue-700 mb-4">Liste des employés</h2>
+    <h2 class="text-xl font-semibold text-sky-700 mb-4">Liste des employés</h2>
     <table class="min-w-full text-left text-sm">
         <thead>
             <tr class="border-b">
@@ -16,12 +16,12 @@ title: Tableau de bord
             </tr>
         </thead>
         <tbody>
-            <tr class="border-b hover:bg-blue-100">
+            <tr class="border-b hover:bg-sky-100">
                 <td class="p-2">Martin Dupont</td>
                 <td class="p-2">Développeur</td>
                 <td class="p-2">Actif</td>
             </tr>
-            <tr class="border-b hover:bg-blue-100">
+            <tr class="border-b hover:bg-sky-100">
                 <td class="p-2">Sophie Durand</td>
                 <td class="p-2">RH</td>
                 <td class="p-2">Actif</td>

--- a/architecture.html
+++ b/architecture.html
@@ -1,0 +1,31 @@
+---
+layout: default
+title: Architecture
+---
+
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
+<p class="mb-4">Vue d\'ensemble du fonctionnement de Dominique&nbsp;IA.</p>
+
+<h2 class="text-xl font-semibold mt-6 mb-2">Processus d\'onboarding initial</h2>
+<img src="https://via.placeholder.com/600x300?text=Onboarding" alt="Sch\u00e9ma d\'onboarding" class="mb-2">
+<ul class="list-disc pl-6 mb-6">
+  <li>Connexion du projet GitLab</li>
+  <li>Param\u00e9trage des r\u00e8gles</li>
+  <li>Activation de l\'analyse</li>
+</ul>
+
+<h2 class="text-xl font-semibold mt-6 mb-2">Pipeline temps r\u00e9el de revue</h2>
+<img src="https://via.placeholder.com/600x300?text=Pipeline" alt="Sch\u00e9ma de revue en temps r\u00e9el" class="mb-2">
+<ul class="list-disc pl-6 mb-6">
+  <li>D\u00e9tection d\'une MR</li>
+  <li>Analyse et g\u00e9n\u00e9ration de la revue</li>
+  <li>Publication du rapport</li>
+</ul>
+
+<h2 class="text-xl font-semibold mt-6 mb-2">Synchronisation planifi\u00e9e du code</h2>
+<img src="https://via.placeholder.com/600x300?text=Synchronisation" alt="Sch\u00e9ma de synchronisation" class="mb-2">
+<ul class="list-disc pl-6">
+  <li>Mise \u00e0 jour p\u00e9riodique du d\u00e9p\u00f4t</li>
+  <li>V\u00e9rifications suppl\u00e9mentaires</li>
+  <li>Nettoyage automatique</li>
+</ul>

--- a/ci-cd.html
+++ b/ci-cd.html
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Déploiement
+---
+
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
+<p class="mb-4">Les mises à jour suivent un processus d'intégration continue.</p>
+<ul class="list-disc pl-6 mb-6 space-y-1">
+  <li>Vérification du code</li>
+  <li>Tests systématiques</li>
+  <li>Déploiement des nouvelles versions</li>
+</ul>
+<p>Une validation est nécessaire avant chaque mise en production.</p>

--- a/conges.html
+++ b/conges.html
@@ -6,7 +6,7 @@ title: Congés
 <h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
 <p class="mb-4">Visualisez les demandes de congés et leur statut en un coup d'œil.</p>
 <div class="bg-white shadow rounded p-4">
-    <h2 class="text-xl font-semibold text-blue-700 mb-4">Historique des demandes de congés</h2>
+    <h2 class="text-xl font-semibold text-sky-700 mb-4">Historique des demandes de congés</h2>
     <table class="min-w-full text-left text-sm">
         <thead>
             <tr class="border-b">
@@ -17,13 +17,13 @@ title: Congés
             </tr>
         </thead>
         <tbody>
-            <tr class="border-b hover:bg-blue-100">
+            <tr class="border-b hover:bg-sky-100">
                 <td class="p-2">Martin Dupont</td>
                 <td class="p-2">01/05/2023</td>
                 <td class="p-2">10/05/2023</td>
                 <td class="p-2">Validé</td>
             </tr>
-            <tr class="border-b hover:bg-blue-100">
+            <tr class="border-b hover:bg-sky-100">
                 <td class="p-2">Sophie Durand</td>
                 <td class="p-2">15/07/2023</td>
                 <td class="p-2">20/07/2023</td>

--- a/cout.html
+++ b/cout.html
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Coût
+---
+
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
+<p class="mb-4">Estimation du coût mensuel de fonctionnement.</p>
+<ul class="list-disc pl-6 mb-6 space-y-1">
+  <li>Hébergement cloud</li>
+  <li>Accès à l'API LLM</li>
+  <li>Stockage et sauvegardes</li>
+</ul>
+<p class="font-semibold">Total estimé&nbsp;: 150&nbsp;&euro; par mois.</p>

--- a/departements.html
+++ b/departements.html
@@ -6,7 +6,7 @@ title: Départements
 <h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
 <p class="mb-4">Retrouvez ici l'ensemble des départements présents dans l'entreprise.</p>
 <div class="bg-white shadow rounded p-4">
-    <h2 class="text-xl font-semibold text-blue-700 mb-4">Liste des départements</h2>
+    <h2 class="text-xl font-semibold text-sky-700 mb-4">Liste des départements</h2>
     <ul class="list-disc pl-6 space-y-1">
         <li>Développement</li>
         <li>Ressources humaines</li>

--- a/employes.html
+++ b/employes.html
@@ -6,7 +6,7 @@ title: Employés
 <h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
 <p class="mb-4">Gérez ici les informations détaillées de chaque collaborateur.</p>
 <div class="bg-white shadow rounded p-4">
-    <h2 class="text-xl font-semibold text-blue-700 mb-4">Liste détaillée des employés</h2>
+    <h2 class="text-xl font-semibold text-sky-700 mb-4">Liste détaillée des employés</h2>
     <table class="min-w-full text-left text-sm">
         <thead>
             <tr class="border-b">
@@ -17,13 +17,13 @@ title: Employés
             </tr>
         </thead>
         <tbody>
-            <tr class="border-b hover:bg-blue-100">
+            <tr class="border-b hover:bg-sky-100">
                 <td class="p-2">Martin Dupont</td>
                 <td class="p-2">Développeur</td>
                 <td class="p-2">martin@example.com</td>
                 <td class="p-2">Actif</td>
             </tr>
-            <tr class="border-b hover:bg-blue-100">
+            <tr class="border-b hover:bg-sky-100">
                 <td class="p-2">Sophie Durand</td>
                 <td class="p-2">RH</td>
                 <td class="p-2">sophie@example.com</td>

--- a/frontend.html
+++ b/frontend.html
@@ -1,0 +1,24 @@
+---
+layout: default
+title: Interface utilisateur
+---
+
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
+<p class="mb-4">La console Dominique permet de suivre facilement vos projets.</p>
+
+<h2 class="text-xl font-semibold mt-6 mb-2">Navigation</h2>
+<p class="mb-2">Accueil &rarr; Liste des projets &rarr; D\u00e9tail d\'un projet &rarr; Liste des MRs &rarr; D\u00e9tail d\'une MR</p>
+
+<h2 class="text-xl font-semibold mt-6 mb-2">Dans une merge request</h2>
+<ul class="list-disc pl-6 mb-6 space-y-1">
+  <li>Diff du code</li>
+  <li>Revue g\u00e9n\u00e9r\u00e9e</li>
+  <li>M\u00e9tadonn\u00e9es : titre, auteur, labels…</li>
+</ul>
+
+<h2 class="text-xl font-semibold mt-6 mb-2">Comportements visuels</h2>
+<ul class="list-disc pl-6 space-y-1">
+  <li>Chargement avec skeletons</li>
+  <li>Affichage optimiste</li>
+  <li>Th\u00e8me clair/sombre</li>
+</ul>

--- a/index.html
+++ b/index.html
@@ -4,10 +4,12 @@ title: Accueil
 ---
 
 <h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
-<p class="mb-4">Bienvenue sur la nouvelle interface du SIRH. Choisissez une section pour commencer :</p>
-<nav class="space-y-2">
-    <a href="admin.html" class="flex items-center gap-2 bg-white p-4 rounded shadow hover:bg-blue-50"><i class="fa-solid fa-chart-line"></i> Tableau de bord</a>
-    <a href="employes.html" class="flex items-center gap-2 bg-white p-4 rounded shadow hover:bg-blue-50"><i class="fa-solid fa-users"></i> Gestion des employés</a>
-    <a href="departements.html" class="flex items-center gap-2 bg-white p-4 rounded shadow hover:bg-blue-50"><i class="fa-solid fa-building"></i> Départements</a>
-    <a href="conges.html" class="flex items-center gap-2 bg-white p-4 rounded shadow hover:bg-blue-50"><i class="fa-solid fa-calendar-days"></i> Congés</a>
-</nav>
+<p class="mb-4">Dominique IA analyse automatiquement vos merge requests GitLab pour vous faire gagner du temps.</p>
+<p class="mb-6 italic">Laissez l\'assistant prendre en charge la revue&nbsp;!</p>
+<ul class="list-disc pl-6 mb-6 space-y-1">
+  <li>Analyse automatique des changements</li>
+  <li>Revue générée par LLM</li>
+  <li>Intégration transparente avec GitLab</li>
+  <li>Interface intuitive</li>
+</ul>
+<a href="architecture.html" class="text-sky-700 underline">Voir l\'architecture du projet</a>

--- a/observabilite.html
+++ b/observabilite.html
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Observabilité
+---
+
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
+<p class="mb-4">Dominique IA vous informe en temps réel de l'état des revues.</p>
+<ul class="list-disc pl-6 mb-6 space-y-1">
+  <li>Alerte en cas d'erreur</li>
+  <li>Notification quand une revue est terminée</li>
+</ul>
+<p>Les temps de réponse et les erreurs sont surveillés en permanence pour garantir la fiabilité du service.</p>

--- a/regles.html
+++ b/regles.html
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Règles projet
+---
+
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
+<p class="mb-4">Chaque projet peut définir ses propres règles.</p>
+<ul class="list-disc pl-6 mb-6 space-y-1">
+  <li>Labels interdits</li>
+  <li>Branches ignorées</li>
+  <li>Niveau de couverture minimum</li>
+  <li>Approbation automatique</li>
+</ul>
+<p class="mb-4">Exemple&nbsp;: refuser les MRs portant le label <code>WIP</code> ou n'affichant pas 80&nbsp;% de couverture.</p>

--- a/roadmap.html
+++ b/roadmap.html
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Prochaines étapes
+---
+
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
+<ul class="list-disc pl-6 mb-6 space-y-1">
+  <li>Mise en place de nouvelles règles personnalisables</li>
+  <li>Support des groupes GitLab</li>
+  <li>Amélioration de l'interface</li>
+</ul>
+<p>N'hésitez pas à nous transmettre vos idées pour la suite.</p>

--- a/securite.html
+++ b/securite.html
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Sécurité
+---
+
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
+<ul class="list-disc pl-6 mb-6 space-y-1">
+  <li>Isolation des données par projet</li>
+  <li>Accès réservé aux utilisateurs autorisés</li>
+  <li>Protections supplémentaires pour la confidentialité</li>
+</ul>
+<p>Les projets sont strictement séparés afin que les informations ne soient jamais partagées.</p>


### PR DESCRIPTION
## Summary
- revamp homepage for Dominique IA
- add architecture, frontend, security, ci-cd, rules, observability, cost, and roadmap pages
- update header and navigation sidebar for the new pages
- update theme with modern blues and mobile-friendly sidebar

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a98cc2dc83309949cae152bf6607