### PR TITLE
Add project list with detail page

### DIFF
--- a/assets/interface.js
+++ b/assets/interface.js
@@ -1,0 +1,51 @@
+const projects = [
+  { id: 1, name: 'Projet Alpha', status: 'En cours' },
+  { id: 2, name: 'Projet Beta', status: 'Terminé' },
+  { id: 3, name: 'Projet Gamma', status: 'En attente' },
+  { id: 4, name: 'Projet Delta', status: 'En cours' },
+  { id: 5, name: 'Projet Epsilon', status: 'Terminé' },
+  { id: 6, name: 'Projet Zeta', status: 'En cours' },
+  { id: 7, name: 'Projet Eta', status: 'En cours' },
+  { id: 8, name: 'Projet Theta', status: 'En attente' },
+  { id: 9, name: 'Projet Iota', status: 'Terminé' },
+  { id: 10, name: 'Projet Kappa', status: 'En cours' }
+];
+
+const rowsPerPage = 5;
+let currentPage = 1;
+let filtered = projects;
+
+function renderTable() {
+  const table = document.getElementById('project-table');
+  const start = (currentPage - 1) * rowsPerPage;
+  const end = start + rowsPerPage;
+  const rows = filtered.slice(start, end).map(p => `
+    <tr class="border-b hover:bg-sky-100">
+      <td class="p-2"><a href="projet.html" class="text-sky-600 hover:underline">${p.name}</a></td>
+      <td class="p-2">${p.status}</td>
+      <td class="p-2 space-x-2">
+        <a href="projet.html" class="text-sky-600" title="Voir"><i class="fa-solid fa-eye"></i></a>
+        <a href="#" class="text-green-600" title="Éditer"><i class="fa-solid fa-pen-to-square"></i></a>
+        <a href="#" class="text-red-600" title="Supprimer"><i class="fa-solid fa-trash"></i></a>
+      </td>
+    </tr>
+  `).join('');
+  table.innerHTML = rows;
+
+  document.getElementById('page-info').textContent = `Page ${currentPage} / ${Math.max(1, Math.ceil(filtered.length / rowsPerPage))}`;
+  document.getElementById('prev').disabled = currentPage === 1;
+  document.getElementById('next').disabled = end >= filtered.length;
+}
+
+function applyFilter(value) {
+  filtered = projects.filter(p => p.name.toLowerCase().includes(value.toLowerCase()));
+  currentPage = 1;
+  renderTable();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('search').addEventListener('input', e => applyFilter(e.target.value));
+  document.getElementById('prev').addEventListener('click', () => { if (currentPage > 1) { currentPage--; renderTable(); } });
+  document.getElementById('next').addEventListener('click', () => { if ((currentPage * rowsPerPage) < filtered.length) { currentPage++; renderTable(); } });
+  renderTable();
+});

--- a/interface.html
+++ b/interface.html
@@ -5,6 +5,27 @@ title: Interface
 
 <h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
 
+<div class="bg-white shadow rounded p-4 mb-6">
+  <div class="flex justify-between mb-4">
+    <input id="search" type="text" class="border p-2 rounded w-full md:w-1/3" placeholder="Filtrer les projets">
+  </div>
+  <table class="min-w-full text-left text-sm">
+    <thead>
+      <tr class="border-b">
+        <th class="p-2">Nom</th>
+        <th class="p-2">Statut</th>
+        <th class="p-2">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="project-table"></tbody>
+  </table>
+  <div class="flex justify-between items-center mt-4">
+    <button id="prev" class="px-3 py-1 bg-sky-200 rounded disabled:opacity-50">Précédent</button>
+    <span id="page-info"></span>
+    <button id="next" class="px-3 py-1 bg-sky-200 rounded disabled:opacity-50">Suivant</button>
+  </div>
+</div>
+
 <h2 class="text-xl font-semibold mt-6 mb-2">Parcours utilisateur</h2>
 <p class="mb-4">Dashboard &rarr; Projets &rarr; Détail projet &rarr; Liste des MRs &rarr; Détail MR &rarr; Revue automatique</p>
 
@@ -18,3 +39,5 @@ title: Interface
 
 <p class="mb-4">L'interface affiche des skeletons pendant le chargement et adopte une UI optimiste. Les mises à jour se font en temps réel grâce à un WebSocket.</p>
 <p>Le thème clair ou sombre est entièrement supporté et les longues listes sont virtualisées pour conserver de bonnes performances.</p>
+
+<script src="assets/interface.js"></script>

--- a/projet.html
+++ b/projet.html
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Détail projet
+---
+
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
+<div class="bg-white shadow rounded p-4 space-y-2">
+  <h2 class="text-xl font-semibold text-sky-700">Projet Exemple</h2>
+  <p>Statut : <span class="font-semibold">En cours</span></p>
+  <p>Ce projet illustre la page de détail accessible depuis la liste.</p>
+  <a href="interface.html" class="text-sky-600 inline-flex items-center gap-1 mt-4"><i class="fa-solid fa-arrow-left"></i> Retour à la liste</a>
+</div>


### PR DESCRIPTION
## Summary
- add interactive project list with filtering and pagination
- add icons for view, edit and delete actions
- link to new `projet.html` page containing project details

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68414946af0083309319d276115d8941