### PR TITLE
Add Gabriel page with animation

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -9,5 +9,6 @@
         <a href="{{ '/observabilite.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-chart-bar"></i> Observabilité</a>
         <a href="{{ '/cout.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-euro-sign"></i> Coût</a>
         <a href="{{ '/roadmap.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-road"></i> Roadmap</a>
+        <a href="{{ '/gabriel.html' | relative_url }}" class="flex items-center gap-2 py-2 px-3 rounded hover:bg-sky-200"><i class="fa-solid fa-user"></i> Gabriel</a>
     </nav>
 </aside>

--- a/gabriel.html
+++ b/gabriel.html
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Gabriel
+---
+
+<h1 class="text-2xl font-bold mb-4">{{ page.title }}</h1>
+<p id="greeting" class="text-lg">Salut Gabriel, comment ça va ?</p>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    gsap.from('#greeting', { scale: 0, opacity: 0, duration: 1, ease: 'elastic.out(1, 0.5)' });
+  });
+</script>


### PR DESCRIPTION
## Summary
- add a new `Gabriel` page with GSAP animation
- link the new page in the sidebar navigation

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848513dbc3c833081fa3af8fac1c500